### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/localization/core.py
+++ b/src/localization/core.py
@@ -21,7 +21,7 @@ def init():
   locale.setlocale(locale.LC_ALL, '')  # use user's preferred locale
   loc = locale.getlocale()
   loc_code = loc[0][0:2]  # take first two characters of country code
-  filename = "data/loc/yahtr_%s.mo" % loc_code
+  filename = "data/loc/yahtr_{0!s}.mo".format(loc_code)
 
   try:
     trans = gettext.GNUTranslations(open(filename, "rb"))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:fp12:yahtr?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:fp12:yahtr?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)